### PR TITLE
alerts: make capacity checks more robust

### DIFF
--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 ---
 apiVersion: v1
 name: prometheus-openstack-exporter
-version: 0.3.3
+version: 0.3.4
 appVersion: v0.8.0

--- a/charts/prometheus-openstack-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-openstack-exporter/templates/prometheusrule.yaml
@@ -142,7 +142,15 @@ spec:
 
     - alert: NovaCapacity
       expr: |
-        sum(openstack_nova_memory_used_bytes) / sum(openstack_nova_memory_available_bytes) * 100 > 75
+        sum (
+            openstack_nova_memory_used_bytes
+          + on(hostname) group_left(adminState)
+            (0 * openstack_nova_agent_state{exported_service="nova-compute",adminState="enabled"})
+        ) / sum (
+            openstack_nova_memory_available_bytes
+          + on(hostname) group_left(adminState)
+            (0 * openstack_nova_agent_state{exported_service="nova-compute",adminState="enabled"})
+        ) * 100 > 75
       labels:
         severity: warning
       annotations:


### PR DESCRIPTION
This change makes the capacity checks a lot more robust by actually
excluding nodes which are in disabled state as well.