### PR TITLE
Feature: clouds.yaml as a kubernetes secret (v0.4.0)

### DIFF
--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 name: prometheus-openstack-exporter
 version: 0.4.0
-appVersion: v1.0.0
+appVersion: v1.2.0

--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 ---
 apiVersion: v1
 name: prometheus-openstack-exporter
-version: 0.3.5
+version: 0.4.0
 appVersion: v1.0.0

--- a/charts/prometheus-openstack-exporter/templates/deployment.yaml
+++ b/charts/prometheus-openstack-exporter/templates/deployment.yaml
@@ -34,9 +34,8 @@ spec:
           containerPort: 9180
       volumes:
       - name: openstack-config
-        hostPath:
-          path: /root/.config/openstack
-          type: Directory
+        secret:
+          secretName: openstack-config
     {{- with .Values.hostAliases }}
       hostAliases:
 {{ toYaml . | indent 8 }}

--- a/charts/prometheus-openstack-exporter/templates/secret.yaml
+++ b/charts/prometheus-openstack-exporter/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-config
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{ .Values.clouds_yaml_config }}

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -4,7 +4,7 @@ cloud: default
 
 image:
   repository: quay.io/niedbalski/openstack-exporter-linux-amd64
-  tag: master
+  tag: v1.2.0
   pullPolicy: Always
 
 serviceMonitor:

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -10,3 +10,29 @@ image:
 serviceMonitor:
   interval: 1m
   scrapeTimeout: 30s
+
+# Add extra args to the exporter.
+# Doc: https://github.com/openstack-exporter/openstack-exporter#command-line-options
+#extraArgs:
+#  - --disable-service.baremetal
+#  - --disable-service.container-infra
+#  - --disable-service.object-store
+
+# Add extra labels
+#commonLabels:
+#  prometheus.io/monitor: "true"
+
+# Generate a secret for clouds.yaml
+# Doc: https://github.com/openstack-exporter/openstack-exporter#openstack-configuration
+clouds_yaml_config: |
+  clouds.yaml: |
+      clouds:
+        default:
+          region_name: your-region-here
+          auth:
+            username: your-user-here
+            password: your-password-here
+            project_name: your-project-here
+            project_domain_name: 'Default'
+            user_domain_name: 'Default'
+            auth_url: 'http://your-url-here:5000/v3'


### PR DESCRIPTION
This commit adds a secret template to provide clouds.yaml as a Kubernetes Secret.
It also adds a few examples in the values.yaml.

Bumped version to 0.4.0 (could change to 1.0.0 if you use strict semver)

This is tested under Kubernetes 1.18+, should work with several previous versions (apiVersion).

Let me know if everything is fine for you.

David