### PR TITLE
Allow adding extra volumes to openstack-exporter deployment

### DIFF
--- a/charts/prometheus-openstack-exporter/templates/deployment.yaml
+++ b/charts/prometheus-openstack-exporter/templates/deployment.yaml
@@ -27,8 +27,11 @@ spec:
         {{- . | toYaml | nindent 8 }}
         {{- end }}
         volumeMounts:
-          - name: openstack-config
-            mountPath: /etc/openstack
+        - name: openstack-config
+          mountPath: /etc/openstack
+        {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9180
@@ -36,6 +39,9 @@ spec:
       - name: openstack-config
         secret:
           secretName: openstack-config
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
     {{- with .Values.hostAliases }}
       hostAliases:
 {{ toYaml . | indent 8 }}

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -23,6 +23,21 @@ serviceMonitor:
 #commonLabels:
 #  prometheus.io/monitor: "true"
 
+# Add extra volumes mounted to openstack-exporter deployment
+# Useful for mounting CA Certificates
+#extraVolumes:
+#- name: company-ca
+#  configMap:
+#    name: my-company-ca
+#    items:
+#    - key: ca
+#      path: my-company-ca
+#
+#extraVolumeMounts:
+#- mountPath: /etc/ssl/certs/my-company-ca
+#  name: company-ca
+#  subPath: my-company-ca
+
 # Generate a secret for clouds.yaml
 # Doc: https://github.com/openstack-exporter/openstack-exporter#openstack-configuration
 clouds_yaml_config: |


### PR DESCRIPTION
This small change allows consumers to mount arbitrary volumes into openstack-exporter Deployment.

Here are example values to mount CA certificate of someone's company as ConfigMap into the Deployment.

```yaml
extraVolumes:
- name: company-ca
  configMap:
    name: my-company-ca
    items:
    - key: ca
      path: my-company-ca

extraVolumeMounts:
- mountPath: /etc/ssl/certs/my-company-ca
  name: company-ca
  subPath: my-company-ca
```

ConfigMap can look like this:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: my-company-ca
data:
  ca: |
    -----BEGIN CERTIFICATE-----
    ....
    -----END CERTIFICATE-----
```

This CaCert can be then used within cloud config `cloud.yaml`:

```yaml
clouds:
  default:
    region_name: RegionZero
    auth:
      username: "user"
      password: "pass"
      project_name: "my-project"
      project_domain_name: "project-domain"
      user_domain_name: "user-domain"
      auth_url: "https://keystone.example.com:5000"
    verify: true
    cacert: /etc/ssl/certs/my-company-ca
```

Signed-off-by: Ondrej Vasko <o.vasko@pan-net.eu>