### PR TITLE
Feature: Add multicloud support

### DIFF
--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 ---
 apiVersion: v1
 name: prometheus-openstack-exporter
-version: 0.4.2
-appVersion: v1.4.0
+version: 0.4.3
+appVersion: v1.6.0

--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 name: prometheus-openstack-exporter
 version: 0.4.2
-appVersion: v1.2.0
+appVersion: v1.4.0

--- a/charts/prometheus-openstack-exporter/templates/deployment.yaml
+++ b/charts/prometheus-openstack-exporter/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
         args:
         - --endpoint-type
         - {{ .Values.endpoint_type }}
+{{- if .Values.multicloud.enabled }}
+        - --multi-cloud
+{{- else }}
         - {{ .Values.cloud }}
+{{- end }}
         {{- with .Values.extraArgs }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/charts/prometheus-openstack-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-openstack-exporter/templates/servicemonitor.yaml
@@ -1,3 +1,60 @@
+{{- if .Values.multicloud.enabled }}
+{{- $fullname := include "openstack-exporter.fullname" . }}
+{{- $labels   := include "openstack-exporter.labels" . }}
+{{- range .Values.multicloud.clouds }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullname }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+{{- $labels | indent 4 }}
+spec:
+  endpoints:
+  - interval: {{ $.Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ $.Values.serviceMonitor.scrapeTimeout }}
+    port: metrics
+    path: /probe
+    params:
+      cloud:
+        - {{ .name }}
+      include_services:
+        - {{ join "," .services }}
+    relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: {{ .name }}
+      targetLabel: instance
+  jobLabel: jobLabel
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+{{- $labels | indent 6 }}
+{{- end }}
+{{- if .Values.multicloud.selfmonitor }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openstack-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "openstack-exporter.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    port: metrics
+  jobLabel: jobLabel
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+{{- include "openstack-exporter.labels" . | indent 6 }}
+{{- end }}
+{{- else }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -22,3 +79,4 @@ spec:
   selector:
     matchLabels:
 {{ include "openstack-exporter.labels" . | indent 6 }}
+{{- end }}

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/niedbalski/openstack-exporter-linux-amd64
-  tag: v1.4.0
+  tag: v1.6.0
   pullPolicy: Always
 
 serviceMonitor:

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -1,16 +1,37 @@
 ---
 # Choose endpoint type (this will override the value of clouds.yaml)
 endpoint_type: internal
+# Ignored when multicloud.enabled: true
 cloud: default
 
 image:
   repository: quay.io/niedbalski/openstack-exporter-linux-amd64
-  tag: v1.2.0
+  tag: v1.4.0
   pullPolicy: Always
 
 serviceMonitor:
   interval: 1m
   scrapeTimeout: 30s
+
+multicloud:
+  # Enable multicloud (i.e. /probe?... targets)
+  # Doc: https://github.com/openstack-exporter/openstack-exporter#description
+  enabled: true
+  # Monitor the exporter's internal metrics (i.e. /metrics)
+  selfmonitor: true
+  # List of clouds to scrape, and the services to scrape from them
+  clouds:
+    - name: cloud1
+      services:
+        - volume
+    - name: cloud2
+      services:
+        - volume
+        - image
+        - identity
+        - compute
+        - network
+        - placement # NB this needs the openstack-exporter release > 1.4.0
 
 # Add extra args to the exporter.
 # Doc: https://github.com/openstack-exporter/openstack-exporter#command-line-options
@@ -37,3 +58,8 @@ clouds_yaml_config: |
             project_domain_name: 'Default'
             user_domain_name: 'Default'
             auth_url: 'http://your-url-here:5000/v3'
+# In case of multicloud.enabled
+#        cloud1:
+#         ...
+#        cloud2:
+#         ...


### PR DESCRIPTION
Hey @niedbalski - this adds multi-cloud support to the Helm Chart.

(The example values.yaml includes my placement-api changes from the exporter, so it would be ideal to release a 1.4.1 of the openstack-exporter containing those changes alongside this, or just drop them from the example values.yaml)