### PR TITLE
Add ReplicaSet support

### DIFF
--- a/charts/prometheus-openstack-exporter/templates/deployment.yaml
+++ b/charts/prometheus-openstack-exporter/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
 {{- include "openstack-exporter.labels" . | indent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
 {{- include "openstack-exporter.labels" . | indent 6 }}

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -3,6 +3,8 @@
 endpoint_type: internal
 cloud: default
 
+replicaCount: 1
+
 image:
   repository: quay.io/niedbalski/openstack-exporter-linux-amd64
   tag: v1.2.0


### PR DESCRIPTION
This small change adds ReplicaSet support to the helm chart.

`replicaCount` var is used to control number of replicas 