### PR TITLE
Move image to new github location

### DIFF
--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -7,8 +7,8 @@ cloud: default
 replicaCount: 1
 
 image:
-  repository: quay.io/niedbalski/openstack-exporter-linux-amd64
-  tag: v1.6.0
+  repository: ghcr.io/openstack-exporter/openstack-exporter
+  tag: 1.6.0
   pullPolicy: Always
 
 serviceMonitor:


### PR DESCRIPTION
This pull request addresses the need to move the current image to the new GitHub Container Registry location. The new location is set to be ghcr.io/openstack-exporter/openstack-exporter.