### PR TITLE
Bump prometheus-openstack-exporter chart and app versions

### DIFF
--- a/charts/prometheus-openstack-exporter/Chart.yaml
+++ b/charts/prometheus-openstack-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 ---
 apiVersion: v1
 name: prometheus-openstack-exporter
-version: 0.4.3
-appVersion: v1.6.0
+version: 0.4.4
+appVersion: v1.7.0

--- a/charts/prometheus-openstack-exporter/values.yaml
+++ b/charts/prometheus-openstack-exporter/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/openstack-exporter/openstack-exporter
-  tag: 1.6.0
+  tag: 1.7.0
   pullPolicy: Always
 
 serviceMonitor:


### PR DESCRIPTION
This PR does:
- Bump prometheus-openstack-exporter app version to v1.7.0 
- Bump prometheus-openstack-exporter chart version to 0.4.4

Refer to: https://github.com/openstack-exporter/openstack-exporter/releases/tag/v1.7.0